### PR TITLE
Force  in query params in URL even if they are replaced with . It is …

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -906,7 +906,7 @@ dependencies = [
 
 [[package]]
 name = "lbasedb-api"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "actix-cors",
  "actix-web",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lbasedb-api"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2024"
 authors = ["Alexander Khlebushchev"]
 license = "MIT"

--- a/src/resource/data.rs
+++ b/src/resource/data.rs
@@ -17,7 +17,9 @@ struct Query {
 
 
 async fn get_view(appdata: WebAppData, req: HttpRequest) -> APIResult {
-    let query = serde_qs::from_str::<Query>(&req.query_string()).unwrap();
+    let qs = req.query_string();
+    let qs = qs.replace("%5B%5D=", "[]=");  // Force `[]` if they are replaced
+    let query = serde_qs::from_str::<Query>(&qs).unwrap();
     let ds = appdata.db.data_get(
         &query.feed,
         query.ix.unwrap(),


### PR DESCRIPTION
…needed for multiple values.